### PR TITLE
Add snapshot saving/restoring to dev tools

### DIFF
--- a/src/TeaCup/DevTools.ts
+++ b/src/TeaCup/DevTools.ts
@@ -191,11 +191,11 @@ export class DevTools<Model,Msg> {
     snapshot() {
         localStorage.setItem(snapshotKey, JSON.stringify(this.lastModel()));
         console.log(
-              "******************************************************************\n"
+              "********************************************************************\n"
             + "*** The current application state has been saved to local storage.\n"
             + "*** The application will now load with this initial state.\n"
             + "*** Call 'teaCupDevTools.clearSnapshot()' to restore normal loading.\n"
-            + "*******************************************************************"
+            + "********************************************************************"
         );
     }
 

--- a/src/TeaCup/DevTools.ts
+++ b/src/TeaCup/DevTools.ts
@@ -85,7 +85,6 @@ function restore(v: any): object {
     if (typeof v === "string" && v.endsWith("Z")) {
         try {
             return new Date(v);
-            // eslint-disable-next-line no-empty
         } catch (e) {
         }
     }
@@ -213,7 +212,6 @@ export class DevTools<Model,Msg> {
                 );
                 return noCmd(model);
             } catch (e) {
-                // eslint-disable-next-line no-console
                 console.log("*** Error restoring state from local storage: ", e);
             }
         }

--- a/src/TeaCup/Program.ts
+++ b/src/TeaCup/Program.ts
@@ -127,7 +127,7 @@ export class Program<Model,Msg> extends Component<ProgramProps<Model,Msg>, Progr
         if (this.devTools) {
             this.devTools.connected(this);
         }
-        const mac = props.init();
+        const mac = (this.devTools && this.devTools.initFromSnapshot()) || props.init();
         if (this.devTools) {
             this.fireEvent({
                 tag: "init",


### PR DESCRIPTION
- `teaCupDevTools.snapshot()` saves the last model to local storage
- Program calls `teaCupDevTools.initFromSnapshot()` to check if there is a saved model and if so inits from it
- `teaCupDevTools.clearSnapshot()` clears the snapshot from local storage to go back to normal loading