### PR TITLE
fix empty hash in navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tea-cup",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tea-cup",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "Put some TEA in your React.",
   "author": "Rémi Van Keisbelck <remi@rvkb.com>",
   "license": "MIT",

--- a/src/TeaCup/Navigation.test.ts
+++ b/src/TeaCup/Navigation.test.ts
@@ -122,6 +122,10 @@ expectNotFound("/songs/1");
 expectNotFound("/song");
 expectNotFound("/song/abc");
 expectNotFound("/song/123/foo");
+expectSettingRouteHash("/settings#blah", just("blah"));
+expectSettingRouteHash("/settings", nothing);
+expectSettingRouteHash("/settings?hello", nothing);
+expectSettingRouteHash("/settings?hello#blah", just("blah"));
 
 
 
@@ -165,6 +169,24 @@ function locFromUrl(url:string): Loc {
     }
 }
 
+function locationFromLoc(url: string, loc: Loc): Location {
+    return {
+        ancestorOrigins: null as unknown as DOMStringList,
+        assign(url: string): void {},
+        hash: url.includes('#') ? url.split('#')[1] : '',
+        host: '',
+        hostname: '',
+        href: '',
+        origin: '',
+        pathname: loc.pathname,
+        port: '',
+        protocol: '',
+        reload(): void {},
+        replace(url: string): void {},
+        search: ''
+    };
+}
+
 function expectRoute(url:string, route: MyRoute) {
     return test(url, () => {
         const loc = locFromUrl(url);
@@ -179,4 +201,21 @@ function expectNotFound(url:string) {
     })
 }
 
+
+function expectSettingRouteHash(url: string, hash: Maybe<string>){
+    return test(url + " (hash)", () => {
+        const loc = locFromUrl(url);
+        const location: Location = locationFromLoc(url, loc);
+        const route: Maybe<MyRoute> = router.parseLocation(location);
+        route
+            .map(r => {
+                if (r.type === 'settings') {
+                    return expect(r.section).toEqual(hash);
+                }
+                throw new Error('Not the settings route!');
+            })
+            .withDefaultSupply(() => { throw new Error('Invalid Route!') });
+    });
+
+}
 

--- a/src/TeaCup/Navigation.tsx
+++ b/src/TeaCup/Navigation.tsx
@@ -289,7 +289,9 @@ export class QueryParams {
             }
         });
 
-        return new QueryParams(store, maybeOf(hash).map(h => h.startsWith("#") ? h.substring(1) : h));
+        return new QueryParams(store,
+            hash === '' ? nothing : maybeOf(hash).map(h => h.startsWith("#") ? h.substring(1) : h)
+        );
     }
 
 }


### PR DESCRIPTION
# Fix empty hash navigation

The navigation was broken. The hash URL was always returning `just('')` when there wasn't any hash!
Now, we return `nothing` in case the hash is not present or empty.