### PR TITLE
Added a way to transform Maybe to nativeJs

### DIFF
--- a/src/TeaCup/Maybe.test.ts
+++ b/src/TeaCup/Maybe.test.ts
@@ -107,3 +107,11 @@ test("map2", () => {
     expect(map2(nothing, just(10), ((a, b) => a + b))).toEqual(nothing);
 });
 
+
+test("To native", () => {
+    const obj = { groovy: "baby"};
+    let mbObj = just(obj);
+    expect(mbObj.toNative()).toEqual(obj)
+    mbObj = nothing;
+    expect(mbObj.toNative()).toEqual(undefined)
+})

--- a/src/TeaCup/Maybe.ts
+++ b/src/TeaCup/Maybe.ts
@@ -67,6 +67,10 @@ export class Just<T> {
     andThen<T2>(f: (t:T) => Maybe<T2>): Maybe<T2> {
         return f(this.value)
     }
+
+    toNative(): T | undefined {
+        return this.value;
+    }
 }
 
 
@@ -112,6 +116,10 @@ export class Nothing<T> {
 
     andThen<T2>(f: (t:T) => Maybe<T2>): Maybe<T2> {
         return nothing;
+    }
+
+    toNative(): T | undefined {
+        return undefined;
     }
 }
 


### PR DESCRIPTION
This PR allows the user to transform the functional representation of an optional to a native Javascript Object.

Example of usage.

```typescript
interface Sample {
  readonly groovy?: string;
}

const obj: Sample = { groovy: 'baby' };
const mbGroovy = maybeOf(obj.groovy); // equivalent of just(obj.groovy)
const groovy = mbGroovy.toNative(); // is returning obj.groovy
// ---- OR ----
const obj: Sample = {};
const mbGroovy = maybeOf(obj.groovy); // equivalent of nothing
const groovy = mbGroovy.toNative(); // is returning undefined
```