### PR TITLE
Allow Tasks with never to chain

### DIFF
--- a/core/src/TeaCup/Task.test.ts
+++ b/core/src/TeaCup/Task.test.ts
@@ -86,6 +86,28 @@ test('from lambda', (done) => {
   expectOk(done, t, 123);
 });
 
+test('Chaining type propagation 1', (done) => {
+  const t1: Task<string, never> = Task.fail('ok');
+  const t2: Task<number, never> = Task.fail(12);
+  const t: Task<string | number, string> = t1.andThen(() => t2)
+  expectErr(done, t, 'ok');
+});
+
+test('Chaining type propagation 2', (done) => {
+  const t1: Task<never, string> = Task.succeed('ok');
+  const t2: Task<number, never> = Task.fail(12);
+  const t: Task<never | number, never> = t1.andThen(() => t2)
+  expectErr(done, t, 12);
+});
+
+test('Chaining type propagation 3', (done) => {
+  const t1: Task<never, number> = Task.succeed(50);
+  const t2: Task<Error, string> = Task.fromLambda(() => 'string');
+  const t: Task<never | Error, string> = t1.andThen(() => t2)
+  expectOk(done, t, 'string');
+});
+
+
 export function attempt<E, R>(t: Task<E, R>, callback: (r: Result<E, R>) => void) {
   Task.attempt(t, (m) => m).execute(callback);
 }

--- a/core/src/TeaCup/Task.ts
+++ b/core/src/TeaCup/Task.ts
@@ -159,13 +159,13 @@ class TThen<E, R, R2, E2> extends Task<E | E2, R2> {
   }
 
   execute(callback: (r: Result<E | E2, R2>) => void): void {
-    this.task.execute((r: Result<E, R>) => {
+    this.task.execute((r: Result<E | E2, R>) => {
       r.match(
         (r: R) => {
           const next = this.f(r);
           next.execute(callback);
         },
-        (e: E) => {
+        (e: E | E2) => {
           callback(new Err(e));
         },
       );

--- a/core/src/TeaCup/Task.ts
+++ b/core/src/TeaCup/Task.ts
@@ -106,7 +106,7 @@ export abstract class Task<E, R> {
    * Chain this task with another task
    * @param f a function that accepts the result of this task, and yields a new task
    */
-  andThen<R2>(f: (r: R) => Task<E, R2>): Task<E, R2> {
+  andThen<R2, E2>(f: (r: R) => Task<E2, R2>): Task<E | E2, R2> {
     return new TThen(this, f);
   }
 }
@@ -148,17 +148,17 @@ class TPromise<R> extends Task<any, R> {
   }
 }
 
-class TThen<E, R, R2> extends Task<E, R2> {
+class TThen<E, R, R2, E2> extends Task<E | E2, R2> {
   private readonly task: Task<E, R>;
-  private readonly f: (r: R) => Task<E, R2>;
+  private readonly f: (r: R) => Task<E2, R2>;
 
-  constructor(task: Task<E, R>, f: (r: R) => Task<E, R2>) {
+  constructor(task: Task<E, R>, f: (r: R) => Task<E2, R2>) {
     super();
     this.task = task;
     this.f = f;
   }
 
-  execute(callback: (r: Result<E, R2>) => void): void {
+  execute(callback: (r: Result<E | E2, R2>) => void): void {
     this.task.execute((r: Result<E, R>) => {
       r.match(
         (r: R) => {

--- a/core/src/TeaCup/Time.test.ts
+++ b/core/src/TeaCup/Time.test.ts
@@ -24,7 +24,8 @@
  */
 
 import { Time } from './Time';
-import { perform } from './Task.test';
+import { expectErr, expectOk, perform } from './Task.test';
+import { Task } from './Task';
 
 const margin = 10;
 
@@ -46,3 +47,18 @@ test('in', (done) => {
     done();
   });
 });
+
+test('Time is chainable with success', (done) => {
+  const t1: Task<never, number> = Time.now();
+  const t2: Task<Error, string> = Task.fromLambda(() => 'test');
+  const t: Task<never|Error, string> = t1.andThen(() => t2);
+  expectOk(done, t, 'test')
+});
+
+test('Time is chainable with success', (done) => {
+  const err = new Error('test');
+  const t1: Task<never, number> = Time.now();
+  const t2: Task<Error, string> = Task.fromLambda(() => { throw err });
+  const t: Task<never|Error, string> = t1.andThen(() => t2);
+  expectErr(done, t, err);
+})


### PR DESCRIPTION
Fixes #31 

The Tasks does not propagate the same error type anymore, it is now an union type of all the error types.