### PR TITLE
introduce mapObject

### DIFF
--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -215,6 +215,11 @@ describe('mapObject', () => {
       foo: Decode.field('foo', Decode.str),
       bar: Decode.optionalField('bar', Decode.num)
     }).decodeValue(value)).toEqual(ok(expected));
+
+    // the type system will compile fail this test:
+    expect(Decode.mapObject<MyType2>({
+      foo: Decode.field('foo', Decode.str),
+    }).decodeValue(value)).toEqual(ok(expected));
   })
 })
 

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -154,7 +154,43 @@ test('map8', () => {
       field('h', num),
     ).decodeValue(o),
   ).toEqual(ok(o));
+
 });
+
+describe('mapObject', () => {
+  type MyType = {
+    foo: string,
+    bar: number
+  };
+  const expected: MyType = {
+    foo: 'a foo',
+    bar: 13
+  }
+
+  test('simple', () => {
+    const value = { foo: 'a foo', bar: 13 }
+    expect(Decode.mapObject({
+      foo: Decode.str,
+      bar: Decode.num
+    }).decodeValue(value)).toEqual(ok(expected));
+  })
+
+  test('missing field', () => {
+    const value = { foo: 'a foo' }
+    expect(Decode.mapObject({
+      foo: Decode.str,
+      bar: Decode.num
+    }).decodeValue(value)).toEqual(err('path not found [bar] on {"foo":"a foo"}'));
+  })
+
+  test('superfluous field', () => {
+    const value = { foo: 'a foo', bar: 13, toto: true }
+    expect(Decode.mapObject({
+      foo: Decode.str,
+      bar: Decode.num
+    }).decodeValue(value)).toEqual(ok(expected));
+  })
+})
 
 test('andThen', () => {
   type Stuff = { readonly tag: 'stuff1'; readonly foo: string } | { readonly tag: 'stuff2'; readonly bar: string };

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -258,7 +258,7 @@ describe('mapArray', () => {
   test('simple', () => {
     type ValueType = [string, number]
     const value: ValueType = ['a foo', 13]
-    expect(Decode.mapArray<ValueType>([
+    expect(Decode.mapTuple<ValueType>([
       Decode.str,
       Decode.num
     ]).decodeValue(value)).toEqual(ok(expected));
@@ -274,8 +274,8 @@ describe('mapArray', () => {
     //   Decode.str
     // ]).decodeValue(value)).toEqual(err('ran into decoder error at [1] : value is not a string : 13'));
 
-    // the type system will let though to runtime: 
-    expect(Decode.mapArray([
+    // the type system will let though to runtime:
+    expect(Decode.mapTuple([
       Decode.str,
       Decode.str
     ]).decodeValue(value)).toEqual(err('ran into decoder error at [1] : value is not a string : 13'));
@@ -286,9 +286,9 @@ describe('mapArray', () => {
     // the type system will compile fail this test:
     // const value: ValueType  = ['a foo']
 
-    // the type system will let though to runtime: 
+    // the type system will let though to runtime:
     const value = ['a foo']
-    expect(Decode.mapArray([
+    expect(Decode.mapTuple([
       Decode.str,
       Decode.num
     ]).decodeValue(value)).toEqual(err('path not found [1] on [\"a foo\"]'));
@@ -299,9 +299,9 @@ describe('mapArray', () => {
     // the type system will compile fail this test:
     // const value: ValueType = ['a foo', 13, true]
 
-    // the type system will let though to runtime: 
+    // the type system will let though to runtime:
     const value = ['a foo', 13, true]
-    expect(Decode.mapArray([
+    expect(Decode.mapTuple([
       Decode.str,
       Decode.num
     ]).decodeValue(value)).toEqual(ok(expected));

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { Decode, Decoder } from './Decode';
+import { Decode, Decoder, DecoderObject } from './Decode';
 import { err, ok } from './Result';
 import { just, nothing } from './Maybe';
 const num = Decode.num;
@@ -178,7 +178,7 @@ describe('mapObject', () => {
 
   test('simpler', () => {
     const value = { foo: 'a foo', bar: 13 }
-    expect(Decode.mapObject<MyType>(Decode.mapFields({
+    expect(Decode.mapObject<MyType>(Decode.mapRequiredFields({
       foo: Decode.str,
       bar: Decode.num
     })).decodeValue(value)).toEqual(ok(expected));
@@ -231,12 +231,12 @@ describe('mapObject', () => {
       foo: 'a foo',
     }
 
-    const decoder = {
+    const decoder: DecoderObject<MyType2> = {
       ...Decode.mapRequiredFields({
         foo: Decode.str,
       }),
       ...Decode.mapOptionalFields({
-        bar: Decode.num
+        bar: Decode.num,
       })
     }
 
@@ -455,7 +455,7 @@ describe('optional field', () => {
 
     const value = { foo: 'a foo', toto: true }
     expect(Decode.mapObject<MyType2>({
-      ...Decode.mapFields({
+      ...Decode.mapRequiredFields({
         foo: Decode.str,
       }),
       bar: Decode.optionalField('bar', Decode.num)

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -192,6 +192,52 @@ describe('mapObject', () => {
   })
 })
 
+describe('mapArray', () => {
+  type MyType = [
+    string,
+    number
+  ]
+  const expected: MyType = [
+    'a foo',
+    13
+  ]
+
+  test('simple', () => {
+    const value = ['a foo', 13]
+    expect(Decode.mapArray([
+      Decode.str,
+      Decode.num
+    ]).decodeValue(value)).toEqual(ok(expected));
+  })
+
+  test('type mismatch', () => {
+    // TODO help the type system compile fail?
+    const value = ['a foo', 13]
+    expect(Decode.mapArray([
+      Decode.str,
+      Decode.str
+    ]).decodeValue(value)).toEqual(err('ran into decoder error at [1] : value is not a string : 13'));
+  })
+
+  test('missing item', () => {
+    // TODO help the type system compile fail?
+    const value = ['a foo']
+    expect(Decode.mapArray([
+      Decode.str,
+      Decode.num
+    ]).decodeValue(value)).toEqual(err('path not found [1] on [\"a foo\"]'));
+  })
+
+  test('too many items', () => {
+    // TODO help the type system compile fail?
+    const value = ['a foo', 13, true]
+    expect(Decode.mapArray([
+      Decode.str,
+      Decode.num
+    ]).decodeValue(value)).toEqual(ok(expected));
+  })
+})
+
 test('andThen', () => {
   type Stuff = { readonly tag: 'stuff1'; readonly foo: string } | { readonly tag: 'stuff2'; readonly bar: string };
 

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -217,9 +217,9 @@ describe('mapObject', () => {
     }).decodeValue(value)).toEqual(ok(expected));
 
     // the type system will compile fail this test:
-    expect(Decode.mapObject<MyType2>({
-      foo: Decode.field('foo', Decode.str),
-    }).decodeValue(value)).toEqual(ok(expected));
+    // expect(Decode.mapObject<MyType2>({
+    //   foo: Decode.field('foo', Decode.str),
+    // }).decodeValue(value)).toEqual(ok(expected));
   })
 })
 

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -221,6 +221,28 @@ describe('mapObject', () => {
     //   foo: Decode.field('foo', Decode.str),
     // }).decodeValue(value)).toEqual(ok(expected));
   })
+
+  test('simpler optional field', () => {
+    type MyType2 = {
+      foo: string,
+      bar?: number
+    };
+    const expected: MyType2 = {
+      foo: 'a foo',
+    }
+
+    const decoder = {
+      ...Decode.mapRequiredFields({
+        foo: Decode.str,
+      }),
+      ...Decode.mapOptionalFields({
+        bar: Decode.num
+      })
+    }
+
+    const value = { foo: 'a foo', toto: true }
+    expect(Decode.mapObject<MyType2>(decoder).decodeValue(value)).toEqual(ok(expected));
+  })
 })
 
 describe('mapArray', () => {

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -170,28 +170,52 @@ describe('mapObject', () => {
   test('simple', () => {
     const value = { foo: 'a foo', bar: 13 }
     expect(Decode.mapObject<MyType>({
-      foo: Decode.str,
-      bar: Decode.num
+      foo: Decode.field('foo', Decode.str),
+      bar: Decode.field('bar', Decode.num)
     }).decodeValue(value)).toEqual(ok(expected));
   })
+
+
+  test('simpler', () => {
+    const value = { foo: 'a foo', bar: 13 }
+    expect(Decode.mapObject<MyType>(Decode.mapFields({
+      foo: Decode.str,
+      bar: Decode.num
+    })).decodeValue(value)).toEqual(ok(expected));
+  })
+
 
   test('missing field', () => {
     const value = { foo: 'a foo' }
     expect(Decode.mapObject<MyType>({
-      foo: Decode.str,
-      bar: Decode.num
+      foo: Decode.field('foo', Decode.str),
+      bar: Decode.field('bar', Decode.num)
     }).decodeValue(value)).toEqual(err('path not found [bar] on {"foo":"a foo"}'));
   })
 
   test('superfluous field', () => {
     const value = { foo: 'a foo', bar: 13, toto: true }
     expect(Decode.mapObject<MyType>({
-      foo: Decode.str,
-      bar: Decode.num
+      foo: Decode.field('foo', Decode.str),
+      bar: Decode.field('bar', Decode.num)
     }).decodeValue(value)).toEqual(ok(expected));
   })
 
+  test('optional field', () => {
+    type MyType2 = {
+      foo: string,
+      bar?: number
+    };
+    const expected: MyType2 = {
+      foo: 'a foo',
+    }
 
+    const value = { foo: 'a foo', toto: true }
+    expect(Decode.mapObject<MyType2>({
+      foo: Decode.field('foo', Decode.str),
+      bar: Decode.optionalField('bar', Decode.num)
+    }).decodeValue(value)).toEqual(ok(expected));
+  })
 })
 
 describe('mapArray', () => {
@@ -391,5 +415,23 @@ describe('optional field', () => {
       Decode.field('foo', Decode.str),
       Decode.optionalField('gnu', Decode.num)).decodeValue(value)
     ).toEqual(ok(expected));
+  })
+
+  test('simpler optional field', () => {
+    type MyType2 = {
+      foo: string,
+      bar?: number
+    };
+    const expected: MyType2 = {
+      foo: 'a foo',
+    }
+
+    const value = { foo: 'a foo', toto: true }
+    expect(Decode.mapObject<MyType2>({
+      ...Decode.mapFields({
+        foo: Decode.str,
+      }),
+      bar: Decode.optionalField('bar', Decode.num)
+    }).decodeValue(value)).toEqual(ok(expected));
   })
 });

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -24,8 +24,6 @@
  */
 
 import { Decode, Decoder, DecoderObject } from './Decode';
-import { err, ok } from './Result';
-import { Decode, Decoder } from './Decode';
 import { err, ok, Result } from './Result';
 import { just, nothing } from './Maybe';
 const num = Decode.num;
@@ -495,3 +493,4 @@ describe('null types', () => {
       .decodeValue(value)
     ).toEqual(ok(expected));
   })
+})

--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -169,7 +169,7 @@ describe('mapObject', () => {
 
   test('simple', () => {
     const value = { foo: 'a foo', bar: 13 }
-    expect(Decode.mapObject({
+    expect(Decode.mapObject<MyType>({
       foo: Decode.str,
       bar: Decode.num
     }).decodeValue(value)).toEqual(ok(expected));
@@ -177,7 +177,7 @@ describe('mapObject', () => {
 
   test('missing field', () => {
     const value = { foo: 'a foo' }
-    expect(Decode.mapObject({
+    expect(Decode.mapObject<MyType>({
       foo: Decode.str,
       bar: Decode.num
     }).decodeValue(value)).toEqual(err('path not found [bar] on {"foo":"a foo"}'));
@@ -185,11 +185,13 @@ describe('mapObject', () => {
 
   test('superfluous field', () => {
     const value = { foo: 'a foo', bar: 13, toto: true }
-    expect(Decode.mapObject({
+    expect(Decode.mapObject<MyType>({
       foo: Decode.str,
       bar: Decode.num
     }).decodeValue(value)).toEqual(ok(expected));
   })
+
+
 })
 
 describe('mapArray', () => {
@@ -203,16 +205,25 @@ describe('mapArray', () => {
   ]
 
   test('simple', () => {
-    const value = ['a foo', 13]
-    expect(Decode.mapArray([
+    type ValueType = [string, number]
+    const value: ValueType = ['a foo', 13]
+    expect(Decode.mapArray<ValueType>([
       Decode.str,
       Decode.num
     ]).decodeValue(value)).toEqual(ok(expected));
   })
 
   test('type mismatch', () => {
-    // TODO help the type system compile fail?
-    const value = ['a foo', 13]
+    type ValueType = [string, number]
+    const value: ValueType = ['a foo', 13]
+
+    // the type system will compile fail this test:
+    // expect(Decode.mapArray<ValueType>([
+    //   Decode.str,
+    //   Decode.str
+    // ]).decodeValue(value)).toEqual(err('ran into decoder error at [1] : value is not a string : 13'));
+
+    // the type system will let though to runtime: 
     expect(Decode.mapArray([
       Decode.str,
       Decode.str
@@ -220,7 +231,11 @@ describe('mapArray', () => {
   })
 
   test('missing item', () => {
-    // TODO help the type system compile fail?
+    type ValueType = [string, number]
+    // the type system will compile fail this test:
+    // const value: ValueType  = ['a foo']
+
+    // the type system will let though to runtime: 
     const value = ['a foo']
     expect(Decode.mapArray([
       Decode.str,
@@ -229,7 +244,11 @@ describe('mapArray', () => {
   })
 
   test('too many items', () => {
-    // TODO help the type system compile fail?
+    type ValueType = [string, number]
+    // the type system will compile fail this test:
+    // const value: ValueType = ['a foo', 13, true]
+
+    // the type system will let though to runtime: 
     const value = ['a foo', 13, true]
     expect(Decode.mapArray([
       Decode.str,

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -462,7 +462,7 @@ export class Decode {
 
   /**
    * Convenience, map decoder object to another decoder object
-   * @param dobject an object with decoders 
+   * @param dobject an object with decoders
    * @param fun the mapper function
    */
   static mapFields<T, T2>(decoders: DecoderObject<T>, fun: DecoderObjectMapper<T, T2>): DecoderObject<T2> {
@@ -485,7 +485,7 @@ export class Decode {
   }
 
   /**
-  * Convenience, map docoders to optional field decoders
+  * Convenience, map decoders to optional field decoders
   * @param dobject an object with decoders
   */
   static mapOptionalFields<T>(decoders: DecoderObject<T>): DecoderObject<OptionalFields<T>> {
@@ -495,11 +495,11 @@ export class Decode {
   }
 
   /**
-   * Decoder for big objects, where map8() is not enough.
+   * Decoder for fixed-length tuples.
    * @param darray an array with decoders
    */
-  static mapArray<T extends any[]>(darray: DecoderArray<T>): Decoder<T> {
-    return Decode.map(v => Object.values(v) as T, this.mapObject<T>(this.mapRequiredFields<T>(darray)));
+  static mapTuple<T extends any[]>(decoders: DecoderArray<T>): Decoder<T> {
+    return Decode.map(v => Object.values(v) as T, this.mapObject<T>(this.mapRequiredFields<T>(decoders)));
   }
 
   // Fancy Decoding

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -550,10 +550,5 @@ function getProperty<T, K extends keyof T>(o: T, key: K): T[K] {
   return o[key];
 }
 
-
-type DecoderObject<T> = { [P in keyof T]: Decoder<T[P]> }
-type DecoderArray<A extends any[]> = { [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }
-
-// TODO need required?
-// type DecoderObject<T> = Required<{ [P in keyof T]: Decoder<T[P]> }>
-// type DecoderArray<A extends any[]> = Required<{ [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }>
+type DecoderObject<T> = Required<{ [P in keyof T]: Decoder<T[P]> }>
+type DecoderArray<A extends any[]> = Required<{ [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }>

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -452,6 +452,14 @@ export class Decode {
     return Decode.map(v => v as T, partialDecoder);
   }
 
+  /**
+ * Decoder for big objects, where map8() is not enough.
+ * @param darray an array with decoders
+ */
+  static mapArray<T extends any[]>(darray: DecoderArray<T>): Decoder<T> {
+    return Decode.map(v => Object.values(v) as T, this.mapObject(darray));
+  }
+
   // Fancy Decoding
 
   /**
@@ -523,6 +531,9 @@ export class Decode {
   }
 }
 
+
 function getProperty<T, K extends keyof T>(o: T, key: K): T[K] {
   return o[key];
 }
+
+type DecoderArray<A extends any[]> = { [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -467,6 +467,34 @@ export class Decode {
   }
 
   /**
+   * Convenience, map docoders to required field decoders
+   * @param dobject an object with decoders
+   */
+  static mapRequiredFields<T>(decoders: DecoderObject<T>): DecoderObject<T> {
+    const keys = Object.keys(decoders) as Array<keyof typeof decoders>
+    const partial: Partial<DecoderObject<T>> = keys.reduce((acc, key) => {
+      const propertyDecoder = getProperty(decoders, key);
+      acc[key] = Decode.field(key as string, propertyDecoder);
+      return acc;
+    }, {} as Partial<DecoderObject<T>>)
+    return partial as DecoderObject<T>;
+  }
+
+  /**
+  * Convenience, map docoders to optional field decoders
+  * @param dobject an object with decoders
+  */
+  static mapOptionalFields<T>(decoders: DecoderObject<T>): DecoderObjectWithOptionals<T> {
+    const keys = Object.keys(decoders) as Array<keyof typeof decoders>
+    const partial: Partial<DecoderObjectWithOptionals<T>> = keys.reduce((acc, key) => {
+      const propertyDecoder = getProperty(decoders, key);
+      acc[key] = Decode.optionalField(key as string, propertyDecoder);
+      return acc;
+    }, {} as Partial<DecoderObjectWithOptionals<T>>)
+    return partial as DecoderObjectWithOptionals<T>;
+  }
+
+  /**
    * Decoder for big objects, where map8() is not enough.
    * @param darray an array with decoders
    */
@@ -551,4 +579,5 @@ function getProperty<T, K extends keyof T>(o: T, key: K): T[K] {
 }
 
 type DecoderObject<T> = Required<{ [P in keyof T]: Decoder<T[P]> }>
+type DecoderObjectWithOptionals<T> = Required<{ [P in keyof T]: Decoder<T[P] | undefined> }>
 type DecoderArray<A extends any[]> = Required<{ [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }>

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -447,17 +447,31 @@ export class Decode {
       return Decode.map(property => {
         object[key] = property;
         return object;
-      }, Decode.field(key as string, propertyDecoder));
+      }, propertyDecoder);
     }, dacc), Decode.succeed({} as Partial<T>))
     return Decode.map(v => v as T, partialDecoder);
   }
 
   /**
- * Decoder for big objects, where map8() is not enough.
- * @param darray an array with decoders
- */
+   * Convenience, map docoders to field decoders
+   * @param dobject an object with decoders 
+   */
+  static mapFields<T>(decoders: DecoderObject<T>): DecoderObject<T> {
+    const keys = Object.keys(decoders) as Array<keyof typeof decoders>
+    const partial: Partial<DecoderObject<T>> = keys.reduce((acc, key) => {
+      const propertyDecoder = getProperty(decoders, key);
+      acc[key] = Decode.field(key as string, propertyDecoder);
+      return acc;
+    }, {} as Partial<DecoderObject<T>>)
+    return partial as DecoderObject<T>;
+  }
+
+  /**
+   * Decoder for big objects, where map8() is not enough.
+   * @param darray an array with decoders
+   */
   static mapArray<T extends any[]>(darray: DecoderArray<T>): Decoder<T> {
-    return Decode.map(v => Object.values(v) as T, this.mapObject<T>(darray));
+    return Decode.map(v => Object.values(v) as T, this.mapObject<T>(this.mapFields<T>(darray)));
   }
 
   // Fancy Decoding

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -440,7 +440,7 @@ export class Decode {
    * Decoder for big objects, where map8() is not enough.
    * @param dobject an object with decoders
    */
-  static mapObject<T>(dobject: { [P in keyof T]: Decoder<T[P]> }): Decoder<T> {
+  static mapObject<T>(dobject: DecoderObject<T>): Decoder<T> {
     const keys = Object.keys(dobject) as Array<keyof typeof dobject>
     const partialDecoder: Decoder<Partial<T>> = keys.reduce((dacc, key) => Decode.andThen(object => {
       const propertyDecoder = getProperty(dobject, key);
@@ -457,7 +457,7 @@ export class Decode {
  * @param darray an array with decoders
  */
   static mapArray<T extends any[]>(darray: DecoderArray<T>): Decoder<T> {
-    return Decode.map(v => Object.values(v) as T, this.mapObject(darray));
+    return Decode.map(v => Object.values(v) as T, this.mapObject<T>(darray));
   }
 
   // Fancy Decoding
@@ -536,4 +536,10 @@ function getProperty<T, K extends keyof T>(o: T, key: K): T[K] {
   return o[key];
 }
 
+
+type DecoderObject<T> = { [P in keyof T]: Decoder<T[P]> }
 type DecoderArray<A extends any[]> = { [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }
+
+// TODO need required?
+// type DecoderObject<T> = Required<{ [P in keyof T]: Decoder<T[P]> }>
+// type DecoderArray<A extends any[]> = Required<{ [P in keyof A]: A[P] extends A[number] ? Decoder<A[P]> : never }>

--- a/core/src/TeaCup/Decode.ts
+++ b/core/src/TeaCup/Decode.ts
@@ -462,7 +462,7 @@ export class Decode {
 
   /**
    * Convenience, map decoder object to another decoder object
-   * @param dobject an object with decoders
+   * @param decoders an object with decoders
    * @param fun the mapper function
    */
   static mapFields<T, T2>(decoders: DecoderObject<T>, fun: DecoderObjectMapper<T, T2>): DecoderObject<T2> {
@@ -478,7 +478,7 @@ export class Decode {
 
   /**
    * Convenience, map docoders to required field decoders
-   * @param dobject an object with decoders
+   * @param decoders an object with decoders
    */
   static mapRequiredFields<T>(decoders: DecoderObject<T>): DecoderObject<T> {
     return this.mapFields(decoders, (k: keyof T, d: Decoder<T[keyof T]>) => [k, Decode.field(k as string, d)]);
@@ -486,7 +486,7 @@ export class Decode {
 
   /**
   * Convenience, map decoders to optional field decoders
-  * @param dobject an object with decoders
+  * @param decoders an object with decoders
   */
   static mapOptionalFields<T>(decoders: DecoderObject<T>): DecoderObject<OptionalFields<T>> {
     const mapper: DecoderObjectMapper<T, OptionalFields<T>> =
@@ -496,7 +496,7 @@ export class Decode {
 
   /**
    * Decoder for fixed-length tuples.
-   * @param darray an array with decoders
+   * @param decoders an array with decoders
    */
   static mapTuple<T extends any[]>(decoders: DecoderArray<T>): Decoder<T> {
     return Decode.map(v => Object.values(v) as T, this.mapObject<T>(this.mapRequiredFields<T>(decoders)));
@@ -521,7 +521,7 @@ export class Decode {
 
   /**
    * Decoder for null
-   * @param the result to yield in case the decoded value is null
+   * @param t the result to yield in case the decoded value is null
    */
   static null<T>(t: T): Decoder<T> {
     return new Decoder<T>((o: any) => {


### PR DESCRIPTION
`mapObject` is useful when decoding objects with more than 8 properties.
`mapArray` is an attempt to decode n-tuples.

