### PR TITLE
Task improvements, UUID module, Maybe.filter

### DIFF
--- a/core/src/TeaCup/Maybe.test.ts
+++ b/core/src/TeaCup/Maybe.test.ts
@@ -139,3 +139,9 @@ test('isNothing', () => {
   expect(n.isJust()).toBe(false);
   expect(n.isNothing()).toBe(true);
 });
+
+test('filter', () => {
+  const m: Maybe<number> = just(123);
+  expect(m.filter(x => x === 123).isJust()).toBe(true);
+  expect(m.filter(x => x === 456).isJust()).toBe(false);
+})

--- a/core/src/TeaCup/Maybe.ts
+++ b/core/src/TeaCup/Maybe.ts
@@ -78,6 +78,13 @@ export class Just<T> {
   isNothing(): boolean {
     return false;
   }
+
+  filter(f:(t:T) => boolean): Maybe<T> {
+    if (f(this.value)) {
+      return this;
+    }
+    return nothing;
+  }
 }
 
 /**
@@ -134,6 +141,11 @@ export class Nothing<T> {
   isNothing(): boolean {
     return true;
   }
+
+  filter(): Maybe<T> {
+    return nothing;
+  }
+
 }
 
 /**

--- a/core/src/TeaCup/UUID.ts
+++ b/core/src/TeaCup/UUID.ts
@@ -23,22 +23,22 @@
  *
  */
 
-export * from './Cmd';
-export * from './Dispatcher';
-export * from './Random';
-export * from './Result';
-export * from './Task';
-export * from './Sub';
-export * from './Animation';
-export * from './Maybe';
-export * from './List';
-export * from './Decode';
-export * from './Http';
-export * from './Tuple';
-export * from './Either';
-export * from './Time';
-export * from './Dict';
-export * from './ListWithSelection';
-export * from './ObjectSerializer';
-export * from './Try';
-export * from './UUID';
+import {Task} from "./Task";
+
+/**
+ * Generate a UUID. Side effect, use uuid() that returns a Task instead
+ */
+export function nextUuid(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Return a Task that generates a UUID
+ */
+export function uuid(): Task<never, string> {
+  return Task.succeedLazy(() => nextUuid());
+}

--- a/tea-cup/src/TeaCup/Program.ts
+++ b/tea-cup/src/TeaCup/Program.ts
@@ -24,7 +24,7 @@
  */
 
 import { Component, ReactNode } from 'react';
-import { Dispatcher, Cmd, Sub } from 'tea-cup-core';
+import { Dispatcher, Cmd, Sub, nextUuid } from 'tea-cup-core';
 import { DevToolsEvent, DevTools } from './DevTools';
 
 /**
@@ -39,21 +39,11 @@ export interface ProgramProps<Model, Msg> {
   devTools?: DevTools<Model, Msg>;
 }
 
-class Guid {
-  static newGuid() {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-      const r = (Math.random() * 16) | 0,
-        v = c == 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
-  }
-}
-
 /**
  * A React component that holds a TEA "program", provides the Dispatcher, and implements the MVU loop.
  */
 export class Program<Model, Msg> extends Component<ProgramProps<Model, Msg>, never> {
-  readonly uuid = Guid.newGuid();
+  readonly uuid = nextUuid();
   private readonly bd: Dispatcher<Msg>;
   private readonly devTools?: DevTools<Model, Msg>;
   private count: number = 0;


### PR DESCRIPTION
Some improvements to `Task` :
* lazy versions for `succeed` and `fail` (useful mostly for easy creation of non-throwing `Task<never,T>`)
* `recover` to turn a failure into a success

Simple yet useful `UUID` module for generating guids.

`Maybe.filter` for filtering Maybes.