### PR TITLE
fix mapObject, create new object for every call

### DIFF
--- a/core/src/TeaCup/Decode.test.ts
+++ b/core/src/TeaCup/Decode.test.ts
@@ -243,6 +243,31 @@ describe('mapObject', () => {
     const value = { foo: 'a foo', toto: true }
     expect(Decode.mapObject<MyType2>(decoder).decodeValue(value)).toEqual(ok(expected));
   })
+
+  it('decode array of mapObject', () => {
+    type MyItem = { gnu: number; foo: string };
+
+    const MyItemDecoder: Decoder<MyItem> = Decode.mapObject(
+      Decode.mapRequiredFields({
+        gnu: Decode.num,
+        foo: Decode.str,
+      }),
+    );
+
+    const payload: MyItem[] = [
+      {
+        gnu: 1,
+        foo: 'a',
+      },
+      {
+        gnu: 2,
+        foo: 'b',
+      },
+    ];
+
+    const r = Decode.array(MyItemDecoder).decodeValue(payload);
+    expect(r).toEqual(ok(payload));
+  });
 })
 
 describe('mapArray', () => {


### PR DESCRIPTION
Resolves #50 

`mapObject` now decodes into a new object at every call.