### PR TITLE
[breaking change] intra peer dependencies / no re-exports

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -11,7 +11,8 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-scripts": "3.4.3",
-    "react-tea-cup": "^1.5.3"
+    "react-tea-cup": "^1.5.3",
+    "tea-cup-core": "^1.5.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/samples/src/App.tsx
+++ b/samples/src/App.tsx
@@ -26,15 +26,19 @@
 import React from 'react';
 import {
   Cmd,
-  DevTools,
   Dispatcher,
   just,
   map,
   Maybe,
   maybeOf,
-  newUrl,
   noCmd,
   nothing,
+  Sub,
+  Task,
+} from 'tea-cup-core';
+import {
+  DevTools,
+  newUrl,
   ProgramWithNav,
   QueryParams,
   route0,
@@ -42,8 +46,6 @@ import {
   route2,
   Router,
   str,
-  Sub,
-  Task,
   withReduxDevTools,
 } from 'react-tea-cup';
 import * as Counter from './Samples/Counter';

--- a/samples/src/Samples/ClassMsgs.tsx
+++ b/samples/src/Samples/ClassMsgs.tsx
@@ -23,7 +23,7 @@
  *
  */
 
-import { Cmd, Dispatcher, noCmd } from 'react-tea-cup';
+import { Cmd, Dispatcher, noCmd } from 'tea-cup-core';
 import * as React from 'react';
 
 export type Model = number;

--- a/samples/src/Samples/Counter.tsx
+++ b/samples/src/Samples/Counter.tsx
@@ -24,7 +24,7 @@
  */
 
 import * as React from 'react';
-import { Dispatcher, Cmd, Sub, noCmd } from 'react-tea-cup';
+import { Dispatcher, Cmd, Sub, noCmd } from 'tea-cup-core';
 
 // model can be anything of course. Here, it
 // is just a number...

--- a/samples/src/Samples/EventsSample.tsx
+++ b/samples/src/Samples/EventsSample.tsx
@@ -24,7 +24,8 @@
  */
 
 import * as React from 'react';
-import { Dispatcher, Cmd, Sub, noCmd, nothing, just, Maybe, DocumentEvents, WindowEvents } from 'react-tea-cup';
+import { Dispatcher, Cmd, Sub, noCmd, nothing, just, Maybe } from 'tea-cup-core';
+import {DocumentEvents, WindowEvents} from "react-tea-cup";
 
 export type Model = {
   clicked: Maybe<MousePosition>

--- a/samples/src/Samples/ParentChild.tsx
+++ b/samples/src/Samples/ParentChild.tsx
@@ -24,7 +24,7 @@
  */
 
 import * as Counter from './Counter';
-import { Dispatcher, map, Cmd, Sub } from 'react-tea-cup';
+import { Dispatcher, map, Cmd, Sub } from 'tea-cup-core';
 import * as React from 'react';
 
 export type Model = ReadonlyArray<Counter.Model>;

--- a/samples/src/Samples/Perf.tsx
+++ b/samples/src/Samples/Perf.tsx
@@ -23,8 +23,9 @@
  *
  */
 
-import { Cmd, Dispatcher, memo, noCmd } from 'react-tea-cup';
+import { Cmd, Dispatcher, noCmd } from 'tea-cup-core';
 import * as React from 'react';
+import { memo } from 'react-tea-cup';
 
 export type Model = Readonly<{
   value: number;

--- a/samples/src/Samples/ProgramSample.test.tsx
+++ b/samples/src/Samples/ProgramSample.test.tsx
@@ -1,38 +1,40 @@
-import { mount, ReactWrapper } from 'enzyme';
-import { extendJest, Cmd, Sub, Task, Program, ProgramProps, updateUntilIdle } from "react-tea-cup";
-import React, { ReactNode } from 'react';
-import { Dispatcher } from 'tea-cup-core';
+import { mount } from 'enzyme';
+import { Cmd, Dispatcher, Sub, Task } from 'tea-cup-core';
+import { extendJest, ProgramProps, updateUntilIdle } from 'react-tea-cup';
+import React from 'react';
 
 extendJest(expect);
 
 const init1: () => [number, Cmd<string>] = () => {
-    return [0, toCmd('go')];
-}
+  return [0, toCmd('go')];
+};
 
-const view1: (dispatch: Dispatcher<string>, model: number) => React.ReactNode = (dispatch: Dispatcher<string>, model: number) => {
-    return (<div className={'count'}>{model}</div>);
-}
+const view1: (dispatch: Dispatcher<string>, model: number) => React.ReactNode = (
+  dispatch: Dispatcher<string>,
+  model: number,
+) => {
+  return <div className={'count'}>{model}</div>;
+};
 
 const update1: (msg: string, model: number) => [number, Cmd<string>] = (msg: string, model: number) => {
-    return [model + 1, model < 5 ? toCmd('go') : Cmd.none()];
-}
+  return [model + 1, model < 5 ? toCmd('go') : Cmd.none()];
+};
 
 // const toCmd = (msg: string) => Task.perform(Time.in(0), () => msg);
 const toCmd = (msg: string) => Task.perform(Task.succeed(0), () => msg);
 
 describe('Test Program', () => {
-
-    it('expect when program is idle', () => {
-        const props: ProgramProps<number, string> = {
-            init: init1,
-            view: view1,
-            update: update1,
-            subscriptions: () => Sub.none<string>()
-        }
-        return updateUntilIdle(props, mount).then(([model, wrapper]) => {
-            expect(model).toEqual(6)
-            // expect(wrapper).toHaveHTML('')
-            expect(wrapper.find('.count')).toHaveText('6')
-        })
-    })
-})
+  it('expect when program is idle', () => {
+    const props: ProgramProps<number, string> = {
+      init: init1,
+      view: view1,
+      update: update1,
+      subscriptions: () => Sub.none<string>(),
+    };
+    return updateUntilIdle(props, mount).then(([model, wrapper]) => {
+      expect(model).toEqual(6);
+      // expect(wrapper).toHaveHTML('')
+      expect(wrapper.find('.count')).toHaveText('6');
+    });
+  });
+});

--- a/samples/src/Samples/Raf.tsx
+++ b/samples/src/Samples/Raf.tsx
@@ -23,7 +23,7 @@
  *
  */
 
-import { Dispatcher, Cmd, noCmd, Sub, onAnimationFrame } from 'react-tea-cup';
+import { Dispatcher, Cmd, noCmd, Sub, onAnimationFrame } from 'tea-cup-core';
 import * as React from 'react';
 
 export interface Model {

--- a/samples/src/Samples/Rand.test.ts
+++ b/samples/src/Samples/Rand.test.ts
@@ -25,7 +25,8 @@
 
 import { view, Msg, update, init } from "./Rand";
 import { shallow } from 'enzyme';
-import { Cmd, extendJest, Testing, nothing, just } from "react-tea-cup";
+import { extendJest, Testing } from "react-tea-cup";
+import { Cmd, nothing, just } from "tea-cup-core";
 
 extendJest(expect);
 const testing = new Testing<Msg>();

--- a/samples/src/Samples/Rand.tsx
+++ b/samples/src/Samples/Rand.tsx
@@ -23,7 +23,7 @@
  *
  */
 
-import { Cmd, Dispatcher, just, Maybe, nothing, Random, Task } from 'react-tea-cup';
+import { Cmd, Dispatcher, just, Maybe, nothing, Random, Task } from 'tea-cup-core';
 import * as React from 'react';
 
 export type Model = Maybe<number>;

--- a/samples/src/Samples/Rest.test.ts
+++ b/samples/src/Samples/Rest.test.ts
@@ -23,108 +23,99 @@
  *
  */
 
-import { view, Msg, init, Model } from "./Rest";
+import { view, Msg, init, Model } from './Rest';
 import { mount } from 'enzyme';
-import { Cmd, extendJest, Testing } from "react-tea-cup";
+import { extendJest, Testing } from 'react-tea-cup';
+import { Cmd } from 'tea-cup-core';
 
 extendJest(expect);
 const testing = new Testing<Msg>();
 
-describe("Test Rest", () => {
+describe('Test Rest', () => {
+  describe('init state', () => {
+    test('triggers message', () => {
+      const [state, cmd] = init();
+      expect(cmd).not.toEqual(Cmd.none());
+    });
+  });
 
-    describe("init state", () => {
+  describe('view state', () => {
+    const [initialState, _cmd] = init();
 
-        test("triggers message", () => {
-            const [state, cmd] = init();
-            expect(cmd).not.toEqual(Cmd.none());
-        });
-
+    test('snapshot initial', () => {
+      const wrapper = mount(view(testing.noop, initialState));
+      expect(wrapper).toMatchSnapshot();
     });
 
-    describe("view state", () => {
-
-        const [initialState, _cmd] = init();
-
-        test("snapshot initial", () => {
-            const wrapper = mount(view(testing.noop, initialState))
-            expect(wrapper).toMatchSnapshot();
-        });
-
-        test("snapshot loaded", () => {
-            const loaded: Model = {
-                tag: "loaded",
-                commits: [{ sha: "13131313", author: "Toto" }]
-            }
-            const wrapper = mount(view(testing.noop, loaded))
-            expect(wrapper).toMatchSnapshot();
-        });
-
-        test("snapshot error", () => {
-            const errored: Model = {
-                tag: "load-error",
-                error: new Error('boom')
-            }
-            const wrapper = mount(view(testing.noop, errored))
-            expect(wrapper).toMatchSnapshot();
-        });
-
+    test('snapshot loaded', () => {
+      const loaded: Model = {
+        tag: 'loaded',
+        commits: [{ sha: '13131313', author: 'Toto' }],
+      };
+      const wrapper = mount(view(testing.noop, loaded));
+      expect(wrapper).toMatchSnapshot();
     });
 
-    describe("clicking generates messages which update", () => {
+    test('snapshot error', () => {
+      const errored: Model = {
+        tag: 'load-error',
+        error: new Error('boom'),
+      };
+      const wrapper = mount(view(testing.noop, errored));
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 
-        test('click list commits', () => {
-            const loaded: Model = {
-                tag: "loaded",
-                commits: [{ sha: "13131313", author: "Toto" }]
-            }
-            const wrapper = mount(view(testing.dispatcher, loaded));
-            wrapper.find('div > button').simulate('click');
+  describe('clicking generates messages which update', () => {
+    test('click list commits', () => {
+      const loaded: Model = {
+        tag: 'loaded',
+        commits: [{ sha: '13131313', author: 'Toto' }],
+      };
+      const wrapper = mount(view(testing.dispatcher, loaded));
+      wrapper.find('div > button').simulate('click');
 
-            const [newState, cmd] = testing.dispatched!(loaded)
-            expect(newState).toEqual({ tag: 'loading' });
-            expect(cmd).not.toEqual(Cmd.none());
-        });
-
-        test('click list commits with loading', () => {
-            const loaded: Model = {
-                tag: "loaded",
-                commits: [{ sha: "13131313", author: "Toto" }]
-            }
-            const wrapper = mount(view(testing.dispatcher, loaded));
-            wrapper.find('div > button').simulate('click');
-
-            const [newState, cmd] = testing.dispatched!(loaded)
-            expect(newState).toEqual({ tag: 'loading' });
-            expect(cmd).not.toEqual(Cmd.none());
-
-            const mockedCommits = [{ sha: "13131313", commit: { author: { name: "Toto" } } }];
-
-            jest.autoMockOff();
-            fetchMock.resetMocks();
-            fetchMock.once(JSON.stringify(mockedCommits));
-
-            testing.dispatchFrom(cmd)
-                .then((msg: Msg) => {
-                    const [newState, cmd1] = msg(loaded);
-                    expect(cmd1).toEqual(Cmd.none());
-                    expect(newState).toEqual({ tag: 'loaded', commits: [{ sha: '13131313', author: 'Toto' }] })
-                })
-        });
-
-        test('click errored', () => {
-            const errored: Model = {
-                tag: "load-error",
-                error: new Error('boom')
-            }
-            const wrapper = mount(view(testing.dispatcher, errored));
-            wrapper.find('div > button').simulate('click');
-
-            const [newState, cmd] = testing.dispatched!(errored)
-            expect(newState).toEqual({ tag: 'loading' });
-            expect(cmd).not.toEqual(Cmd.none());
-        });
-
+      const [newState, cmd] = testing.dispatched!(loaded);
+      expect(newState).toEqual({ tag: 'loading' });
+      expect(cmd).not.toEqual(Cmd.none());
     });
 
+    test('click list commits with loading', () => {
+      const loaded: Model = {
+        tag: 'loaded',
+        commits: [{ sha: '13131313', author: 'Toto' }],
+      };
+      const wrapper = mount(view(testing.dispatcher, loaded));
+      wrapper.find('div > button').simulate('click');
+
+      const [newState, cmd] = testing.dispatched!(loaded);
+      expect(newState).toEqual({ tag: 'loading' });
+      expect(cmd).not.toEqual(Cmd.none());
+
+      const mockedCommits = [{ sha: '13131313', commit: { author: { name: 'Toto' } } }];
+
+      jest.autoMockOff();
+      fetchMock.resetMocks();
+      fetchMock.once(JSON.stringify(mockedCommits));
+
+      testing.dispatchFrom(cmd).then((msg: Msg) => {
+        const [newState, cmd1] = msg(loaded);
+        expect(cmd1).toEqual(Cmd.none());
+        expect(newState).toEqual({ tag: 'loaded', commits: [{ sha: '13131313', author: 'Toto' }] });
+      });
+    });
+
+    test('click errored', () => {
+      const errored: Model = {
+        tag: 'load-error',
+        error: new Error('boom'),
+      };
+      const wrapper = mount(view(testing.dispatcher, errored));
+      wrapper.find('div > button').simulate('click');
+
+      const [newState, cmd] = testing.dispatched!(errored);
+      expect(newState).toEqual({ tag: 'loading' });
+      expect(cmd).not.toEqual(Cmd.none());
+    });
+  });
 });
-

--- a/samples/src/Samples/Rest.tsx
+++ b/samples/src/Samples/Rest.tsx
@@ -23,7 +23,7 @@
  *
  */
 
-import { Http, Cmd, Task, Result, noCmd, Dispatcher, Decode, Decoder } from "react-tea-cup";
+import { Http, Cmd, Task, Result, noCmd, Dispatcher, Decode, Decoder } from "tea-cup-core";
 import * as React from 'react'
 
 export interface Commit {

--- a/samples/src/Samples/StatefulInView.tsx
+++ b/samples/src/Samples/StatefulInView.tsx
@@ -23,8 +23,9 @@
  *
  */
 
-import { Cmd, Dispatcher, memo, noCmd } from 'react-tea-cup';
+import { Cmd, Dispatcher, noCmd } from 'tea-cup-core';
 import * as React from 'react';
+import { memo } from 'react-tea-cup';
 
 export type Model = number;
 

--- a/samples/src/Samples/TimeSample.test.ts
+++ b/samples/src/Samples/TimeSample.test.ts
@@ -23,180 +23,164 @@
  *
  */
 
-import { view, Msg, update, init } from "./TimeSample";
+import { view, Msg, update, init } from './TimeSample';
 import { mount } from 'enzyme';
-import { Cmd, extendJest, Testing } from "react-tea-cup";
+import { extendJest, Testing } from 'react-tea-cup';
+import { Cmd } from 'tea-cup-core';
 
 extendJest(expect);
 const testing = new Testing<Msg>();
 
-describe("Test TimeSample", () => {
+describe('Test TimeSample', () => {
+  describe('init state', () => {
+    test('triggers no message', () => {
+      const [state, cmd] = init();
+      expect(cmd).toEqual(Cmd.none());
+    });
+  });
 
-    describe("init state", () => {
+  describe('view state', () => {
+    const [initialState, _cmd] = init();
 
-        test("triggers no message", () => {
-            const [state, cmd] = init();
-            expect(cmd).toEqual(Cmd.none());
-        });
+    describe('render initial state', () => {
+      test('current time', () => {
+        const wrapper = mount(view(testing.noop, initialState));
 
+        expect(wrapper.find('div').at(0)).toIncludeText('Current time :');
+        expect(wrapper.find('div > button').at(0)).toHaveText('Get current time');
+      });
+
+      test('trigger in', () => {
+        const wrapper = mount(view(testing.noop, initialState));
+
+        expect(wrapper.find('div').at(1)).toIncludeText('In :');
+        expect(wrapper.find('div > button').at(1)).toHaveText('Trigger in');
+      });
+
+      test('ticks', () => {
+        const wrapper = mount(view(testing.noop, initialState));
+
+        expect(wrapper.find('div').at(2)).toIncludeText('Ticks1 :');
+        expect(wrapper.find('div').at(2)).toIncludeText(', ticks2 :');
+        expect(wrapper.find('div > button').at(2)).toHaveText('start ticking');
+      });
+
+      test('snapshot initial', () => {
+        const wrapper = mount(view(testing.noop, initialState));
+        expect(wrapper).toMatchSnapshot();
+      });
     });
 
-    describe("view state", () => {
+    describe('render some state', () => {
+      const state1 = {
+        ...initialState,
+        currentTime: 1313,
+        inTime: true,
+        inProgress: false,
+        ticking: true,
+        ticks1: 13,
+        ticks2: 131313,
+      };
 
-        const [initialState, _cmd] = init();
+      const state2 = {
+        ...state1,
+        inProgress: true,
+      };
 
-        describe("render initial state", () => {
+      test('current time', () => {
+        const wrapper = mount(view(testing.noop, state1));
+        expect(wrapper.find('div').at(0)).toIncludeText('Current time : 1313');
+      });
 
-            test("current time", () => {
-                const wrapper = mount(view(testing.noop, initialState))
+      test('trigger in', () => {
+        const wrapper = mount(view(testing.noop, state1));
+        expect(wrapper.find('div').at(1)).toIncludeText('In :true');
+      });
 
-                expect(wrapper.find('div').at(0)).toIncludeText('Current time :');
-                expect(wrapper.find('div > button').at(0)).toHaveText('Get current time');
-            });
+      test('trigger in progress', () => {
+        const wrapper = mount(view(testing.noop, state2));
+        expect(wrapper.find('div').at(1)).toIncludeText('In :...');
+      });
 
-            test("trigger in", () => {
-                const wrapper = mount(view(testing.noop, initialState))
+      test('ticks', () => {
+        const wrapper = mount(view(testing.noop, state1));
+        expect(wrapper.find('div').at(2)).toIncludeText('Ticks1 : 13');
+        expect(wrapper.find('div').at(2)).toIncludeText('ticks2 : 131313');
+        expect(wrapper.find('div > button').at(2)).toIncludeText('stop ticking');
+      });
 
-                expect(wrapper.find('div').at(1)).toIncludeText('In :');
-                expect(wrapper.find('div > button').at(1)).toHaveText('Trigger in');
-            });
+      test('snapshot state1', () => {
+        const wrapper = mount(view(testing.noop, state1));
+        expect(wrapper).toMatchSnapshot();
+      });
 
-            test("ticks", () => {
-                const wrapper = mount(view(testing.noop, initialState))
+      test('snapshot state2', () => {
+        const wrapper = mount(view(testing.noop, state2));
+        expect(wrapper).toMatchSnapshot();
+      });
+    });
+  });
 
-                expect(wrapper.find('div').at(2)).toIncludeText('Ticks1 :');
-                expect(wrapper.find('div').at(2)).toIncludeText(', ticks2 :');
-                expect(wrapper.find('div > button').at(2)).toHaveText('start ticking');
-            });
+  describe('clicking generates messages', () => {
+    const [initialState, _cmd] = init();
 
-            test("snapshot initial", () => {
-                const wrapper = mount(view(testing.noop, initialState))
-                expect(wrapper).toMatchSnapshot();
-            });
-
-        });
-
-        describe("render some state", () => {
-
-            const state1 = {
-                ...initialState,
-                currentTime: 1313,
-                inTime: true,
-                inProgress: false,
-                ticking: true,
-                ticks1: 13,
-                ticks2: 131313
-            }
-
-            const state2 = {
-                ...state1,
-                inProgress: true
-            }
-
-            test("current time", () => {
-                const wrapper = mount(view(testing.noop, state1))
-                expect(wrapper.find('div').at(0)).toIncludeText('Current time : 1313');
-            });
-
-            test("trigger in", () => {
-                const wrapper = mount(view(testing.noop, state1))
-                expect(wrapper.find('div').at(1)).toIncludeText('In :true');
-            });
-
-            test("trigger in progress", () => {
-                const wrapper = mount(view(testing.noop, state2))
-                expect(wrapper.find('div').at(1)).toIncludeText('In :...');
-            });
-
-            test("ticks", () => {
-                const wrapper = mount(view(testing.noop, state1))
-                expect(wrapper.find('div').at(2)).toIncludeText('Ticks1 : 13');
-                expect(wrapper.find('div').at(2)).toIncludeText('ticks2 : 131313');
-                expect(wrapper.find('div > button').at(2)).toIncludeText('stop ticking');
-            });
-
-            test("snapshot state1", () => {
-                const wrapper = mount(view(testing.noop, state1))
-                expect(wrapper).toMatchSnapshot();
-            });
-
-            test("snapshot state2", () => {
-                const wrapper = mount(view(testing.noop, state2))
-                expect(wrapper).toMatchSnapshot();
-            });
-
-        });
-
+    test('get current time', () => {
+      const wrapper = mount(view(testing.dispatcher, initialState));
+      wrapper.find('div > button').at(0).simulate('click');
+      expect(testing).toHaveDispatchedMsg({ tag: 'get-cur-time' });
     });
 
-    describe("clicking generates messages", () => {
-
-        const [initialState, _cmd] = init();
-
-        test("get current time", () => {
-            const wrapper = mount(view(testing.dispatcher, initialState));
-            wrapper.find('div > button').at(0).simulate('click');
-            expect(testing).toHaveDispatchedMsg({ tag: "get-cur-time" });
-        });
-
-        test("get in", () => {
-            const wrapper = mount(view(testing.dispatcher, initialState));
-            wrapper.find('div > button').at(1).simulate('click');
-            expect(testing).toHaveDispatchedMsg({ tag: "get-in" });
-        });
-
-        test("toggle tick", () => {
-            const wrapper = mount(view(testing.dispatcher, initialState));
-            wrapper.find('div > button').at(2).simulate('click');
-            expect(testing).toHaveDispatchedMsg({ tag: "toggle-tick" });
-        });
-
+    test('get in', () => {
+      const wrapper = mount(view(testing.dispatcher, initialState));
+      wrapper.find('div > button').at(1).simulate('click');
+      expect(testing).toHaveDispatchedMsg({ tag: 'get-in' });
     });
 
-    describe("message updates state", () => {
+    test('toggle tick', () => {
+      const wrapper = mount(view(testing.dispatcher, initialState));
+      wrapper.find('div > button').at(2).simulate('click');
+      expect(testing).toHaveDispatchedMsg({ tag: 'toggle-tick' });
+    });
+  });
 
-        const [initialState, _cmd] = init();
+  describe('message updates state', () => {
+    const [initialState, _cmd] = init();
 
-        test("get-cur-time", () => {
-            const [newState, cmd] = update({ tag: "get-cur-time" }, initialState);
-            expect(newState.currentTime).toBe(-1);
-            testing.dispatchFrom(cmd)
-                .then(msg => {
-                    expect(msg).toHaveProperty('tag', 'got-cur-time')
-                });
-        });
-
-        test("get-in", () => {
-            const [newState, cmd] = update({ tag: "get-in" }, initialState);
-            expect(newState.inTime).toBe(false);
-            expect(newState.inProgress).toBe(true);
-            testing.dispatchFrom(cmd)
-                .then(msg => {
-                    expect(msg).toHaveProperty('tag', 'got-in')
-                });
-        });
-
-        test("toggle-tick", () => {
-            const [newState, cmd] = update({ tag: "toggle-tick" }, initialState);
-            expect(newState.ticking).toBe(!initialState.ticking);
-            expect(cmd).toEqual(Cmd.none())
-        });
-
-        test("got-tick 1", () => {
-            const [newState, cmd] = update({ tag: "got-tick", isFirst: true }, initialState);
-            expect(newState.ticks1).toBe(initialState.ticks1 + 1);
-            expect(newState.ticks2).toBe(initialState.ticks2);
-            expect(cmd).toEqual(Cmd.none())
-        });
-
-        test("got-tick 2", () => {
-            const [newState, cmd] = update({ tag: "got-tick", isFirst: false }, initialState);
-            expect(newState.ticks1).toBe(initialState.ticks1);
-            expect(newState.ticks2).toBe(initialState.ticks2 + 1);
-            expect(cmd).toEqual(Cmd.none())
-        });
-
+    test('get-cur-time', () => {
+      const [newState, cmd] = update({ tag: 'get-cur-time' }, initialState);
+      expect(newState.currentTime).toBe(-1);
+      testing.dispatchFrom(cmd).then((msg) => {
+        expect(msg).toHaveProperty('tag', 'got-cur-time');
+      });
     });
 
+    test('get-in', () => {
+      const [newState, cmd] = update({ tag: 'get-in' }, initialState);
+      expect(newState.inTime).toBe(false);
+      expect(newState.inProgress).toBe(true);
+      testing.dispatchFrom(cmd).then((msg) => {
+        expect(msg).toHaveProperty('tag', 'got-in');
+      });
+    });
+
+    test('toggle-tick', () => {
+      const [newState, cmd] = update({ tag: 'toggle-tick' }, initialState);
+      expect(newState.ticking).toBe(!initialState.ticking);
+      expect(cmd).toEqual(Cmd.none());
+    });
+
+    test('got-tick 1', () => {
+      const [newState, cmd] = update({ tag: 'got-tick', isFirst: true }, initialState);
+      expect(newState.ticks1).toBe(initialState.ticks1 + 1);
+      expect(newState.ticks2).toBe(initialState.ticks2);
+      expect(cmd).toEqual(Cmd.none());
+    });
+
+    test('got-tick 2', () => {
+      const [newState, cmd] = update({ tag: 'got-tick', isFirst: false }, initialState);
+      expect(newState.ticks1).toBe(initialState.ticks1);
+      expect(newState.ticks2).toBe(initialState.ticks2 + 1);
+      expect(cmd).toEqual(Cmd.none());
+    });
+  });
 });
-

--- a/samples/src/Samples/TimeSample.tsx
+++ b/samples/src/Samples/TimeSample.tsx
@@ -24,7 +24,7 @@
  */
 
 import * as React from 'react';
-import { Cmd, Dispatcher, noCmd, Sub, Task, Time } from 'react-tea-cup';
+import { Cmd, Dispatcher, noCmd, Sub, Task, Time } from 'tea-cup-core';
 
 export interface Model {
   readonly currentTime: number;

--- a/tea-cup/package.json
+++ b/tea-cup/package.json
@@ -20,10 +20,10 @@
     "samples": "tsc --outFile ./dist/Samples/index.js && cp ./src/Samples/index.html ./dist/Samples"
   },
   "dependencies": {
-    "tea-cup-core": "^1.5.3"
   },
   "peerDependencies": {
-    "react": "^16.7.0"
+    "react": "^16.7.0",
+    "tea-cup-core": "^1.5.3"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.5",

--- a/tea-cup/src/TeaCup/index.ts
+++ b/tea-cup/src/TeaCup/index.ts
@@ -23,7 +23,6 @@
  *
  */
 
-export * from 'tea-cup-core';
 export * from './Memo';
 export * from './Program';
 export * from './Navigation';


### PR DESCRIPTION
Breaking change !! *Will require to change your imports.*

* do not re-export tea-cup-core
* peer dep on tea-cup-core

This will lead to easier dependency management for the integrators. 