### PR TITLE
Added a way to match TS representation of Either

### DIFF
--- a/core/src/TeaCup/Either.test.ts
+++ b/core/src/TeaCup/Either.test.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { Either, left, right } from './Either';
+import { Either, Left, left, Right, right } from './Either';
 
 test('left', () => {
   const e: Either<string, number> = left('yeah');
@@ -66,3 +66,17 @@ test('mapRight', () => {
     ),
   ).toBe(124);
 });
+
+test('toNative', () => {
+  const lefty: Left<string, number> = new Left("hello");
+  const resLeft: string = lefty.toNative();
+  expect(resLeft).toEqual("hello")
+
+  const righty: Right<string, number> = new Right(13);
+  const resRight: number = righty.toNative();
+  expect(resRight).toEqual("hello")
+
+  const either: Either<string, number> = left("surprise");
+  const res: string | number = either.toNative();
+  expect(res).toEqual("surprise")
+})

--- a/core/src/TeaCup/Either.ts
+++ b/core/src/TeaCup/Either.ts
@@ -65,6 +65,10 @@ export class Left<A, B> {
   get right(): Maybe<B> {
     return nothing;
   }
+
+  toNative(): A {
+    return this.value;
+  }
 }
 
 export class Right<A, B> {
@@ -101,6 +105,10 @@ export class Right<A, B> {
 
   get right(): Maybe<B> {
     return just(this.value);
+  }
+
+  toNative(): B {
+    return this.value;
   }
 }
 


### PR DESCRIPTION
This PR adds `toNative()` function in `Either`.

Example:
```typescript
type A = string;
type b = number;

const valLeft: Left<A, B> = new Left("value");
const valRight: Right<A, B> = new Right(13);

const a: A = valLeft.toNative();
const b: B = valRight.toNative();

// With an Either
const valEither: Either<A,  B> = left("value");
const unknown: A | B = vaLEither.toNative();
```

Typescript is automacally changing the `toNative` result with an Union Type.