### PR TITLE
Adding support for React 17

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -7,12 +7,20 @@ test everything. They are not meant to be "good practises".
 
     # make sure tea-cup is compiled
     cd react-tea-cup
-    npm install
-    npm run compile
+    yarn install
+    cd core
+    yarn run compile
+    cd ../tea-cup
+    yarn run compile
 
-    # build and run the samples
-    cd samples
-    npm install
-    npm start
+    # run the samples 
+        # With React 16 (default)
+        cd ../samples
+        yarn start
+    
+        # With React 17
+        cd ../samples
+        yarn upgrade react@^17.0.1 react-dom@^17.0.1 @types/react@^17.0.1 @types/react-dom@^17.0.1
+        yarn start
 
 The samples app is made with `create-react-app`. See the scripts in `package.json`.

--- a/samples/src/App.tsx
+++ b/samples/src/App.tsx
@@ -415,6 +415,7 @@ function viewHome(dispatch: Dispatcher<Msg>) {
         </a>
         .
       </p>
+      <pre>React version: {React.version}</pre>
     </div>
   );
 }

--- a/tea-cup/package.json
+++ b/tea-cup/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.7.0",
+    "react": "^16.7.0 || ^17.0.1",
     "tea-cup-core": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Modifying "peerDependencies" to include either react 16 or 17.
- Added instructions on how to run the samples using React 17