### PR TITLE
fix special subs

### DIFF
--- a/core/src/TeaCup/Animation.ts
+++ b/core/src/TeaCup/Animation.ts
@@ -28,13 +28,16 @@ import { Sub } from './Sub';
 let subs: Array<RafSub<any>> = [];
 
 let ticking = false;
+let triggerNext = 0;
+
 
 function tick() {
   if (!ticking) {
     ticking = true;
     requestAnimationFrame((t: number) => {
-      subs.forEach((s) => s.trigger(t));
       ticking = false;
+      subs[triggerNext]?.trigger(t)
+      triggerNext = (triggerNext + 1) % subs.length
     });
   }
 }

--- a/samples/src/Samples/Raf.tsx
+++ b/samples/src/Samples/Raf.tsx
@@ -29,16 +29,18 @@ import * as React from 'react';
 export interface Model {
   readonly started: boolean;
   readonly t: number;
+  readonly t2: number;
   readonly fps: number;
   readonly animText: string;
 }
 
-export type Msg = { type: 'raf'; t: number } | { type: 'toggle' } | { type: 'text-changed'; text: string };
+export type Msg = { type: 'raf'; t: number } | { type: 'raf2'; t: number } | { type: 'toggle' } | { type: 'text-changed'; text: string };
 
 export function init() {
   return noCmd<Model, Msg>({
     started: false,
     t: 0,
+    t2: 0,
     fps: 0,
     animText: 'This text gets animated...',
   });
@@ -65,6 +67,7 @@ export function view(dispatch: Dispatcher<Msg>, model: Model) {
         />
       </div>
       <span>Time = {Math.round(model.t)}</span>
+      <span>Time2 = {Math.round(model.t2)}</span>
       <button onClick={(_) => dispatch({ type: 'toggle' })}>{model.started ? 'Stop' : 'Start'}</button>
       {fps}
       {anim}
@@ -102,6 +105,7 @@ export function update(msg: Msg, model: Model): [Model, Cmd<Msg>] {
   switch (msg.type) {
     case 'toggle':
       return noCmd({ ...model, started: !model.started });
+
     case 'raf':
       const delta = msg.t - model.t;
       const fps = delta === 0
@@ -112,6 +116,12 @@ export function update(msg: Msg, model: Model): [Model, Cmd<Msg>] {
         t: msg.t,
         fps: fps,
       });
+    case 'raf2':
+      return noCmd({
+        ...model,
+        t2: msg.t,
+      });
+
 
     case 'text-changed':
       return noCmd({
@@ -123,9 +133,13 @@ export function update(msg: Msg, model: Model): [Model, Cmd<Msg>] {
 
 export function subscriptions(model: Model) {
   if (model.started) {
-    return onAnimationFrame((t: number) => {
-      return { type: 'raf', t: t } as Msg;
-    });
+    return Sub.batch([
+      onAnimationFrame((t: number) => {
+        return { type: 'raf', t: t } as Msg;
+      }),
+      onAnimationFrame((t: number) => {
+        return { type: 'raf2', t: t } as Msg;
+      })]);
   } else {
     return Sub.none<Msg>();
   }

--- a/tea-cup/src/TeaCup/DocumentEvents.ts
+++ b/tea-cup/src/TeaCup/DocumentEvents.ts
@@ -42,6 +42,11 @@ class DocSub<K extends keyof Map, Map, Msg> extends Sub<Msg> {
         this.listener = (e) => this.dispatch(this.mapper(e));
     }
 
+    protected dispatch(m: Msg): void {
+        const d = this.dispatcher;
+        d && setTimeout(() => d?.(m));
+    }
+
     protected onInit() {
         super.onInit();
         this.documentEvents.doAddListener(this.key, this.listener, this.options)

--- a/tea-cup/src/TeaCup/Program.ts
+++ b/tea-cup/src/TeaCup/Program.ts
@@ -91,10 +91,8 @@ export class Program<Model, Msg> extends Component<ProgramProps<Model, Msg>, nev
 
       const d = this.dispatch.bind(this);
 
-      setTimeout(() => {
-        newSub.init(d);
-        prevSub?.release();
-      });
+      newSub.init(d);
+      prevSub?.release();
 
       // perform commands in a separate timout, to
       // make sure that this dispatch is done


### PR DESCRIPTION
The renewal of subscriptions needs to be sync'ed within the program's dispatch loop.
Otherwise, conditional subscriptions may miss events.

This fix requires special treatment of built in subscriptions for animations and global dom events, document and window.

The proposed implementation allows animations to drop some frames, making sure multiple subscriptions all get to handle frames.

For document events, dropping events is not an option. Here the proposed implementation accepts to send events to a subscription that might not have been renewed by the last model update.
