### PR TITLE
Reintroduce test helper for Program's MVU loop

### DIFF
--- a/samples/src/Samples/SelectSample.tsx
+++ b/samples/src/Samples/SelectSample.tsx
@@ -56,7 +56,6 @@ export function view(dispatch: Dispatcher<Msg>, model: Model) {
       <select
         value={value}
         onChange={(e) => {
-          console.log('FW onChange', e.target.value);
           dispatch({ type: 'selected', value: e.target.value });
         }}
       >

--- a/tea-cup/src/TeaCup/Program.test.tsx
+++ b/tea-cup/src/TeaCup/Program.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import { Cmd, Dispatcher, Maybe, noCmd, nothing, Result, Sub, Task } from 'tea-cup-fp';
-import { Program, updateUntilIdle } from 'react-tea-cup';
-import { render } from '@testing-library/react';
+import { Cmd, Dispatcher, just, Maybe, noCmd, nothing, Result, Sub, Task } from 'tea-cup-fp';
+import { Program } from './Program';
+import { updateUntilCondition, updateUntilIdle } from './Testing';
+import { render, RenderResult } from '@testing-library/react';
 import * as React from 'react';
 
 interface Model {
@@ -110,4 +111,15 @@ describe('program test', () => {
         done();
       }, 3000);
     }));
+
+  test('update until condition', () => {
+    return updateUntilCondition(
+      { init: init, view: (_d, model) => view(model), update: update, subscriptions: subscriptions },
+      (node) => render(node),
+      (model) => model.other,
+    ).then(([model, { container }]) => {
+      expect(model).toEqual({ id: just('myid'), other: true });
+      expect(container.querySelector('#myid')?.textContent).toEqual('myid,true');
+    });
+  });
 });


### PR DESCRIPTION
`updateUntilCondition` provides a way write unit tests that use the program loop until a condition on the model is met.