### PR TITLE
Add `flushSyncDefault` to `ProgramWithNav`

### DIFF
--- a/tea-cup/src/TeaCup/Navigation.tsx
+++ b/tea-cup/src/TeaCup/Navigation.tsx
@@ -37,6 +37,7 @@ export interface NavProps<Model, Msg> extends ProgramInterop<Model, Msg> {
   readonly view: (dispatch: Dispatcher<Msg>, m: Model) => ReactNode;
   readonly update: (msg: Msg, model: Model) => [Model, Cmd<Msg>];
   readonly subscriptions: (model: Model) => Sub<Msg>;
+  flushSyncDefault?: boolean;
 }
 
 export function ProgramWithNav<Model, Msg>(props: NavProps<Model, Msg>) {
@@ -52,6 +53,7 @@ export function ProgramWithNav<Model, Msg>(props: NavProps<Model, Msg>) {
       listener={props.listener}
       setModelBridge={props.setModelBridge}
       paused={props.paused}
+      flushSyncDefault={props.flushSyncDefault}
     />
   );
 }


### PR DESCRIPTION
Problem: There is a `flushSyncDefault` flag that changes the behavior of how `flushSync` is called. This is included in `Program` but not `ProgramWithNav`.

Solution:
- Add `flushSyncDefault` to `ProgramWithNav`